### PR TITLE
Fix path handling on Windows

### DIFF
--- a/basis/graph/builder.py
+++ b/basis/graph/builder.py
@@ -3,16 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from basis.configuration.base import FrozenPydanticBase, load_yaml, update
+from basis.configuration.base import load_yaml
 from basis.configuration.graph import (
-    GraphDefinitionCfg,
     GraphNodeCfg,
-    InterfaceCfg,
-    NodeConnection,
     NodeDefinitionCfg,
 )
 from basis.configuration.path import (
-    AbsoluteNodeConnection,
     as_absolute_connection,
     join_node_paths,
 )
@@ -59,7 +55,7 @@ def build_configured_nodes(
     (abs_filepath_to_yaml_config, node_def) = find_node_definition(
         node_cfg.node_definition, abs_filepath_to_root
     )
-    node_def_default_name = abs_filepath_to_yaml_config.split("/")[-2]
+    node_def_default_name = abs_filepath_to_yaml_config.parent.name
     node_script_path = None
     if node_def.script is not None:
         node_script_path = str(
@@ -124,9 +120,9 @@ def build_configured_nodes(
 
 def find_node_definition(
     reference: str, abs_filepath_to_root: str
-) -> tuple[str, NodeDefinitionCfg]:
+) -> tuple[Path, NodeDefinitionCfg]:
     ref_path = Path(abs_filepath_to_root) / reference
-    if reference.endswith(".yaml") or reference.endswith(".yml"):
+    if ref_path.suffix in (".yaml", ".yml"):
         yaml_path = ref_path
     else:
         # For now assume it is a dir containing a yaml
@@ -137,4 +133,4 @@ def find_node_definition(
         else:
             raise NotImplementedError(f"Could not find a yml def in {ref_path}")
     node_def = NodeDefinitionCfg(**load_yaml(yaml_path))
-    return str(yaml_path), node_def
+    return yaml_path, node_def

--- a/basis/node/node.py
+++ b/basis/node/node.py
@@ -1,5 +1,6 @@
 import importlib
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
 from basis.configuration.graph import ScriptType
@@ -22,7 +23,7 @@ def get_node_function(node: ConfiguredNode) -> NodeFunction:
     assert (
         node.file_path_to_node_script_relative_to_root is not None
     ), "No script file specified"
-    mod_path = node.file_path_to_node_script_relative_to_root.replace("/", ".")[:-3]
+    mod_path = '.'.join(Path(node.file_path_to_node_script_relative_to_root).with_suffix('').parts)
     # TODO: root must be on path...
     mod = importlib.import_module(mod_path)
     node_fn = find_single_of_type_in_module(mod, NodeFunction)

--- a/basis/utils/modules.py
+++ b/basis/utils/modules.py
@@ -24,9 +24,6 @@ def load_python_file(pth: str, **local_vars: Any) -> dict[str, Any]:
 
 
 def load_module(pth: Path) -> ModuleType:
-    name = pth.parts[-1]
-    if name.endswith(".py"):
-        name = name[:-3]
     parent = str(pth.parent)
     if parent in sys.path:
         exists = True
@@ -34,7 +31,7 @@ def load_module(pth: Path) -> ModuleType:
         exists = False
         sys.path.insert(0, parent)
     try:
-        return import_module(name)
+        return import_module(pth.stem)
     finally:
         if not exists:
             sys.path.remove(parent)
@@ -49,7 +46,7 @@ def find_single_of_type_in_module(module: ModuleType, typ: Type[T]) -> T:
 
 
 def single_of_type_in_path(pth: str, typ: Type[T]) -> T:
-    if "/" in pth or ".py" in pth:
+    if Path(pth).exists():
         # It's a file path to a python file ("folder1/folder2/node1.py")
         return find_single_of_type_in_module(load_module(Path(pth)), typ)
     # Otherwise it is a python import path ("pckg1.mod1.node1")


### PR DESCRIPTION
Some of the code manipulates file paths as strings, and assumes `/` as
the file separator. This PR changes that code to use pathlib instad.