### PR TITLE
Remove some dev-dependencies not used by CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,15 +26,10 @@ black = "^19.10b0"
 # datacopy = {path = "../dcp", develop = true}
 flake8 = "^3.8.1"
 isort = "^4.3.21"
-mkdocs = "^1.1.2"
-mkdocs-material = "^6.1.7"
 mypy = "^0.910"
 pre-commit = "^2.1.1"
-psycopg2-binary = "^2.8.6"
-pydeps = "^1.9.0"
 pytest = "^4.6"
 pytest-cov = "^2.8.1"
-sqlalchemy-stubs = "^0.3"
 
 [tool.poetry.scripts]
 basis = "basis.cli.app:app.run"


### PR DESCRIPTION
CI takes several minutes to run, and ~95% of that time is resolving and installing dependencies. Removing unused dependencies can speed that up a bit.