### PR TITLE
Cache poetry venv

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,4 @@ ignore = E203, E266, E501, W503, F403, F401, F811, F541
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-exclude = basis/cli/templates/templates,examples
+exclude = basis/cli/templates/templates,examples,.venv

--- a/.github/workflows/basis.yml
+++ b/.github/workflows/basis.yml
@@ -19,11 +19,21 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-          poetry install
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
We currently reinstall all dependencies for each CI run. This PR caches the poetry venv between runs, invalidating it any time `pyproject.toml` changes. This should speed up CI builds significantly.