### PR TITLE
Test with Python 3.10 in CI

### DIFF
--- a/.github/workflows/basis.yml
+++ b/.github/workflows/basis.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9," "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,6 +19,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Load cached Poetry installation
+        uses: actions/cache@v2
+        with:
+          path: ~/.local
+          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
@@ -30,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root

--- a/.github/workflows/basis.yml
+++ b/.github/workflows/basis.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9," "3.10"]
+        python-version: ["3.8", "3.9,", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/basis.yml
+++ b/.github/workflows/basis.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9,", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,13 @@ version = "0.1.1"
 common-model = { git = "https://github.com/kvh/common-model.git" }
 datacopy = { git = "https://github.com/kvh/dcp.git" }
 jinja2 = "^3.0.0"
+platformdirs = "^2.4.0"
 pydantic = "^1.8.1"
 python = "^3.8"
 requests-mock = "^1.9.3"
-strictyaml = "^1.0.6"
-typer = {extras = ["all"], version = "^0.4.0"}
-platformdirs = "^2.4.0"
 rich = "^10.15.2"
 ruyaml = "^0.91.0"
+typer = {extras = ["all"], version = "^0.4.0"}
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"
@@ -29,8 +28,7 @@ flake8 = "^4.0.1"
 isort = "^4.3.21"
 mypy = "^0.910"
 pre-commit = "^2.1.1"
-pytest = "^4.6"
-pytest-cov = "^2.8.1"
+pytest = "^6.2.5"
 
 [tool.poetry.scripts]
 basis = "basis.cli.main:main"


### PR DESCRIPTION
Additionally, we cache the poetry install itself to reduce run time
further. Venvs are now cached per-python version rather than sharing a
venv between python versions.