### PR TITLE
Add more functionality to GraphConfigEditor

### DIFF
--- a/basis/cli/commands/create.py
+++ b/basis/cli/commands/create.py
@@ -35,7 +35,7 @@ def graph(
     cfg = read_local_basis_config()
     path = resolve_graph_path(location, exists=False)
     name = name or location.stem
-    path.write_text(dump_yaml({"name": name}))
+    GraphConfigEditor(path, read=False).set_name(name).write()
     write_local_basis_config(cfg)
 
     sprint(f"\n[success]Created graph [b]{name}")

--- a/basis/configuration/edit.py
+++ b/basis/configuration/edit.py
@@ -1,21 +1,30 @@
 import re
 from io import StringIO
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import ruyaml
 
-from basis.configuration.graph import NodeCfg
+from basis.configuration.graph import NodeCfg, ExposingCfg, GraphDefinitionCfg
+from basis.configuration.path import NodeId
+from basis.graph.builder import graph_manifest_from_yaml, _GraphBuilder, _ParsedGraph
+from basis.graph.configured_node import GraphManifest
 
 
 class GraphConfigEditor:
     """Edit a graph.yml file, preserving comments
 
-    Constructing an instance of this class will raise an exception if the yaml file
-    doesn't exist or can't be parsed.
+    By default, constructing an instance of this class will raise an exception if the
+    yaml file doesn't exist or can't be parsed.
+
+    If you pass `read=False` to the constructor, the file won't be read, and you'll
+    start with an empty config.
+
+    You can also pass `path_to_graph_yml=None` if you aren't going to write back to
+    disk.
     """
 
-    def __init__(self, path_to_graph_yml: Path):
+    def __init__(self, path_to_graph_yml: Optional[Path], read: bool = True):
         self._yaml = ruyaml.YAML()
         self._path_to_graph_yml = path_to_graph_yml
         self._yaml.indent(mapping=2, sequence=4, offset=2)
@@ -23,15 +32,20 @@ class GraphConfigEditor:
         # breaks. Ruyaml opens files in binary mode (bypassing universal newline
         # support), then proceeds to behave incorrectly in the presence of \r\n, adding
         # extra line breaks in the output.
-        with self._path_to_graph_yml.open() as f:
-            text = f.read()
-        self._cfg = self._yaml.load(text)
-        # ruyaml doesn't provide a way to preserve indentation,
-        # so pick a value that matches the first list item we see
-        if m := re.search(r"^( *)-", text, re.MULTILINE):
-            indent = len(m.group(1)) + 2
+        if read:
+            with self._path_to_graph_yml.open() as f:
+                text = f.read()
+            self._cfg = self._yaml.load(text) or {}
+            # ruyaml doesn't provide a way to preserve indentation,
+            # so pick a value that matches the first list item we see
+            if m := re.search(r"^( *)-", text, re.MULTILINE):
+                indent = len(m.group(1)) + 2
+            else:
+                indent = 4
         else:
+            self._cfg = {}
             indent = 4
+
         self._yaml.indent(
             mapping=int(indent / 2), sequence=indent, offset=max(0, indent - 2)
         )
@@ -45,6 +59,48 @@ class GraphConfigEditor:
         s = StringIO()
         self._yaml.dump(self._cfg, s)
         return s.getvalue()
+
+    def parse_to_cfg(self) -> GraphDefinitionCfg:
+        """Parse the data to a GraphDefinitionCfg without writing it to disk"""
+        return GraphDefinitionCfg(**self._cfg)
+
+    def parse_to_manifest(self) -> GraphManifest:
+        """Parse the data to a GraphManifest without writing it to disk"""
+        parse_to_cfg = self.parse_to_cfg
+        path_to_graph_yml = self._path_to_graph_yml
+
+        class MemBuilder(_GraphBuilder):
+            def _read_graph_yml(self, path: Path) -> GraphDefinitionCfg:
+                if path_to_graph_yml and path != path_to_graph_yml:
+                    return super()._read_graph_yml(path)
+                if path != self.root_graph_location:
+                    raise NotImplementedError("Cannot construct subgraphs in-memory")
+                return parse_to_cfg()
+
+        if path_to_graph_yml:
+            p = path_to_graph_yml
+        else:
+            p = Path(self.get_name() or "graph") / "graph.yml"
+        return MemBuilder(p).build()
+
+    def set_name(self, name: str) -> "GraphConfigEditor":
+        self._cfg["name"] = name
+        return self
+
+    def get_name(self) -> Optional[str]:
+        return self._cfg.get("name")
+
+    def get_exposing_cfg(self) -> Optional[ExposingCfg]:
+        if "exposes" in self._cfg:
+            return ExposingCfg(**self._cfg["exposes"])
+        return None
+
+    def set_exposing_cfg(self, exposing: Optional[ExposingCfg]) -> "GraphConfigEditor":
+        if exposing is None:
+            del self._cfg["exposes"]
+        else:
+            self._cfg["exposes"] = exposing.dict(exclude_none=True)
+        return self
 
     def add_node_cfg(self, node: NodeCfg) -> "GraphConfigEditor":
         d = node.dict(exclude_none=True)
@@ -101,6 +157,6 @@ class GraphConfigEditor:
         self, webhook: str, name: str = None, id: str = None, description: str = None
     ) -> "GraphConfigEditor":
         self.add_node_cfg(
-            NodeCfg(webhook=webhook, name=name, id=id, description=description,)
+            NodeCfg(webhook=webhook, name=name, id=id, description=description)
         )
         return self

--- a/basis/configuration/graph.py
+++ b/basis/configuration/graph.py
@@ -85,6 +85,4 @@ class ExposingCfg(FrozenPydanticBase):
 class GraphDefinitionCfg(FrozenPydanticBase):
     name: str = None
     exposes: ExposingCfg = None
-    description: str = None
-    schedule: str = None
     nodes: List[NodeCfg] = None

--- a/tests/configuration/test_config_editor.py
+++ b/tests/configuration/test_config_editor.py
@@ -2,6 +2,15 @@ import textwrap
 from pathlib import Path
 
 from basis.configuration.edit import GraphConfigEditor
+from basis.configuration.graph import ExposingCfg, GraphDefinitionCfg, NodeCfg
+from basis.configuration.path import NodeId
+from basis.graph.configured_node import (
+    GraphManifest,
+    CURRENT_MANIFEST_SCHEMA_VERSION,
+    ConfiguredNode,
+    NodeType,
+)
+from tests.graph.utils import setup_manifest
 
 
 def test_round_trip(tmp_path: Path):
@@ -102,6 +111,54 @@ def test_add_node_with_all_fields(tmp_path: Path):
         id="ab234567",
         description="desc",
     ).assert_dump(after)
+
+
+def test_parsing():
+    b = GraphConfigEditor(None, read=False)
+    b.set_name("test")
+    b.add_webhook("hook")
+    manifest = b.parse_to_manifest()
+
+    assert manifest.graph_name == "test"
+    assert manifest.errors == []
+    assert len(manifest.nodes) == 1
+    assert manifest.nodes[0].name == "hook"
+    assert manifest.nodes[0].node_type == NodeType.Webhook
+
+    exposes = ExposingCfg(outputs=["hook"])
+    b.set_exposing_cfg(exposes)
+    cfg = b.parse_to_cfg()
+    assert cfg == GraphDefinitionCfg(
+        name="test", exposes=exposes, nodes=[NodeCfg(webhook="hook")]
+    )
+
+
+def test_parsing_with_subgraph(tmp_path: Path):
+    setup_manifest(
+        tmp_path,
+        {
+            "graph.yml": """
+                name: foo
+                nodes:
+                  - node_file: sub/graph.yml
+            """,
+            "sub/graph.yml": """
+                exposes:
+                  outputs:
+                    - sub_out
+                nodes:
+                  - webhook: sub_out
+            """,
+        },
+    )
+    path = tmp_path / "graph.yml"
+    before = path.read_text()
+    b = GraphConfigEditor(path)
+    b.set_name("bar")
+    m = b.parse_to_manifest()
+    assert m.graph_name == "bar"
+    assert len(m.nodes) == 2
+    assert path.read_text() == before
 
 
 def get_editor(tmp_path: Path, s: str) -> "_EditorTester":


### PR DESCRIPTION
- Edit remaining parts of config
- Parse the builder into a config or manifest directly in memory without needing to write back to disk. This is mostly useful for tests.