### PR TITLE
Connection node param

### DIFF
--- a/basis/__init__.py
+++ b/basis/__init__.py
@@ -8,6 +8,7 @@ from .node.node import (
     OutputStream,
     Parameter,
     State,
+    Connection,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "OutputStream",
     "Parameter",
     "State",
+    "Connection",
 ]

--- a/basis/graph/builder.py
+++ b/basis/graph/builder.py
@@ -169,7 +169,9 @@ class _GraphBuilder:
             for i in exposed_inputs
             if i in input_defs_by_name  # may be missing in broken graphs
         ]
-        return NodeInterface(inputs=inputs, outputs=outputs, parameters=[], state=None)
+        return NodeInterface(
+            inputs=inputs, outputs=outputs, parameters=[], connections=[], state=None
+        )
 
     # set local edges connected to nodes' inputs
     def _set_local_input_edges(
@@ -234,7 +236,11 @@ class _GraphBuilder:
             edges.append(edge)
 
     def _check_edge(
-        self, dst_id: NodeId, name: str, src_t: PortType, dst_t: PortType,
+        self,
+        dst_id: NodeId,
+        name: str,
+        src_t: PortType,
+        dst_t: PortType,
     ):
         if src_t == PortType.Table and dst_t == PortType.Stream:
             self._err(
@@ -298,7 +304,8 @@ class _GraphBuilder:
 
         while vertex.node_type == NodeType.Graph:
             vertex_port = next(
-                (e.input for e in vertex.local_edges if e.output == vertex_port), None,
+                (e.input for e in vertex.local_edges if e.output == vertex_port),
+                None,
             )
             if not vertex_port:
                 self._err(
@@ -384,13 +391,16 @@ class _GraphBuilder:
         assert node.webhook
 
         outputs = [OutputDefinition(port_type=PortType.Stream, name=node.webhook)]
-        ni = NodeInterface(inputs=[], outputs=outputs, parameters=[])
+        ni = NodeInterface(inputs=[], outputs=outputs, parameters=[], connections=[])
         node_name = node.name or node.webhook
         node_id = self._make_node_id(node.id, node_name, parent)
         return _Interface(ni, NodeType.Webhook, [], node_name, node_id, None)
 
     def _parse_file_node_entry(
-        self, node: NodeCfg, node_dir: Path, parent: Optional[NodeId],
+        self,
+        node: NodeCfg,
+        node_dir: Path,
+        parent: Optional[NodeId],
     ) -> _Interface:
         assert node.node_file
 
@@ -401,7 +411,7 @@ class _GraphBuilder:
         try:
             interface = self._parse_node_interface(node, node_file_path, node_id)
         except NodeParseException as e:
-            ni = NodeInterface(inputs=[], outputs=[], parameters=[])
+            ni = NodeInterface(inputs=[], outputs=[], parameters=[], connections=[])
             interface = _Interface(ni, NodeType.Node, [])
             self._err(
                 node_id, f"Error parsing file {relative_node_path}: {e.__cause__}"
@@ -457,5 +467,7 @@ class _GraphBuilder:
         input_def = InputDefinition(
             port_type=PortType.Table, name=node.chart_input, required=True
         )
-        ni = NodeInterface(inputs=[input_def], outputs=[], parameters=[])
+        ni = NodeInterface(
+            inputs=[input_def], outputs=[], parameters=[], connections=[]
+        )
         return _Interface(ni, NodeType.Chart, [])

--- a/basis/graph/configured_node.py
+++ b/basis/graph/configured_node.py
@@ -69,11 +69,12 @@ class ParameterDefinition(FrozenPydanticBase):
 
 class StateDefinition(FrozenPydanticBase):
     name: str
-    
-    
+
+
 class ConnectionDefinition(FrozenPydanticBase):
-    url: str
-    description: str
+    name: str
+    domain: str
+    description: str = None
 
 
 class NodeInterface(FrozenPydanticBase):

--- a/basis/graph/configured_node.py
+++ b/basis/graph/configured_node.py
@@ -69,12 +69,18 @@ class ParameterDefinition(FrozenPydanticBase):
 
 class StateDefinition(FrozenPydanticBase):
     name: str
+    
+    
+class ConnectionDefinition(FrozenPydanticBase):
+    url: str
+    description: str
 
 
 class NodeInterface(FrozenPydanticBase):
     inputs: List[InputDefinition]
     outputs: List[OutputDefinition]
     parameters: List[ParameterDefinition]
+    connections: List[ConnectionDefinition]
     state: StateDefinition = None
 
 

--- a/basis/node/_methods.py
+++ b/basis/node/_methods.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pandas import DataFrame
 from typing import Iterator, Any
 
+from requests import Response
+
 
 class InputTableMethods:
     @classmethod
@@ -67,3 +69,17 @@ class StateMethods:
 
 class ParameterMethods:
     pass
+
+
+class ConnectionMethods:
+    @classmethod
+    def get(cls, url: str, params: dict | None = None) -> Response:
+        ...
+
+    @classmethod
+    def post(cls, url: str, data: dict | None = None) -> Response:
+        ...
+
+    @classmethod
+    def configure(cls, param: str, value: Any):
+        ...

--- a/basis/node/_methods.py
+++ b/basis/node/_methods.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pandas import DataFrame
 from typing import Iterator, Any
 
-from requests import Response
+from requests import Response, Session
 
 
 class InputTableMethods:
@@ -72,6 +72,10 @@ class ParameterMethods:
 
 
 class ConnectionMethods:
+    @classmethod
+    def get_session(cls) -> Session:
+        ...
+    
     @classmethod
     def get(cls, url: str, params: dict | None = None) -> Response:
         ...

--- a/basis/node/_methods.py
+++ b/basis/node/_methods.py
@@ -75,15 +75,15 @@ class ConnectionMethods:
     @classmethod
     def get_session(cls) -> Session:
         ...
-    
+
     @classmethod
-    def get(cls, url: str, params: dict | None = None) -> Response:
+    def get(cls, url: str, params: dict | None = None, **kwargs) -> Response:
         ...
 
     @classmethod
-    def post(cls, url: str, data: dict | None = None) -> Response:
+    def post(cls, url: str, data: dict | None = None, **kwargs) -> Response:
         ...
 
     @classmethod
-    def configure(cls, param: str, value: Any):
+    def configure(cls, **kwargs):
         ...

--- a/basis/node/node.py
+++ b/basis/node/node.py
@@ -12,6 +12,7 @@ from basis.node._methods import (
     InputStreamMethods,
     OutputStreamMethods,
     StateMethods,
+    ConnectionMethods,
 )
 
 
@@ -55,13 +56,17 @@ class _InputMeta(type, _NodeInterfaceEntry):
 
 class _OutputMeta(type, _NodeInterfaceEntry):
     def __new__(
-        mcs, description: str = None, schema: Union[str, Schema] = None,
+        mcs,
+        description: str = None,
+        schema: Union[str, Schema] = None,
     ):
         return super().__new__(mcs, mcs.__name__, (mcs,), _mixin_attrs())
 
     # noinspection PyMissingConstructor
     def __init__(
-        cls, description: str = None, schema: Union[str, Schema] = None,
+        cls,
+        description: str = None,
+        schema: Union[str, Schema] = None,
     ):
         cls.description = description
         cls.schema = schema
@@ -69,17 +74,32 @@ class _OutputMeta(type, _NodeInterfaceEntry):
 
 class _ParameterMeta(type, _NodeInterfaceEntry):
     def __new__(
-        mcs, description: str = None, type: str = None, default: Any = None,
+        mcs,
+        description: str = None,
+        type: str = None,
+        default: Any = None,
     ):
         return super().__new__(mcs, mcs.__name__, (mcs,), _mixin_attrs())
 
     # noinspection PyMissingConstructor
     def __init__(
-        cls, description: str = None, type: str = None, default: Any = None,
+        cls,
+        description: str = None,
+        type: str = None,
+        default: Any = None,
     ):
         cls.description = description
         cls.type = type
         cls.default = default
+
+
+class _ConnectionMeta(type, _NodeInterfaceEntry):
+    def __new__(mcs, description: str = None):
+        return super().__new__(mcs, mcs.__name__, (mcs,), _mixin_attrs())
+
+    # noinspection PyMissingConstructor
+    def __init__(cls, description: str = None):
+        cls.description = description
 
 
 class InputTable(_InputMeta, InputTableMethods):
@@ -102,7 +122,11 @@ class Parameter(_ParameterMeta, ParameterMethods):
     pass
 
 
-class State(_ParameterMeta, StateMethods):
+class State(_OutputMeta, StateMethods):
+    pass
+
+
+class Connection(_ConnectionMeta, ConnectionMethods):
     pass
 
 

--- a/basis/node/node.py
+++ b/basis/node/node.py
@@ -94,11 +94,12 @@ class _ParameterMeta(type, _NodeInterfaceEntry):
 
 
 class _ConnectionMeta(type, _NodeInterfaceEntry):
-    def __new__(mcs, description: str = None):
+    def __new__(mcs, domain: str, description: str = None):
         return super().__new__(mcs, mcs.__name__, (mcs,), _mixin_attrs())
 
     # noinspection PyMissingConstructor
-    def __init__(cls, description: str = None):
+    def __init__(cls, domain: str, description: str = None):
+        cls.domain = domain
         cls.description = description
 
 

--- a/basis/node/sql/jinja.py
+++ b/basis/node/sql/jinja.py
@@ -72,7 +72,11 @@ def _get_jinja_env() -> SandboxedEnvironment:
 
 def _interface_from_jinja_ctx(ctx: BasisJinjaInspectContext) -> NodeInterface:
     return NodeInterface(
-        inputs=ctx.inputs, outputs=ctx.outputs, parameters=ctx.parameters, state=None
+        inputs=ctx.inputs,
+        outputs=ctx.outputs,
+        parameters=ctx.parameters,
+        connections=[],
+        state=None,
     )
 
 

--- a/basis/utils/ast_parser.py
+++ b/basis/utils/ast_parser.py
@@ -10,7 +10,8 @@ from basis.graph.configured_node import (
     OutputDefinition,
     ParameterDefinition,
     PortType,
-    StateDefinition, ConnectionDefinition,
+    StateDefinition,
+    ConnectionDefinition,
 )
 
 
@@ -42,7 +43,11 @@ class _NodeFuncFinder(ast.NodeVisitor):
 
     def interface(self):
         return NodeInterface(
-            inputs=self.i, outputs=self.o, parameters=self.p, state=self.s
+            inputs=self.i,
+            outputs=self.o,
+            parameters=self.p,
+            connections=self.c,
+            state=self.s,
         )
 
     def visit_FunctionDef(self, node: ast.FunctionDef):
@@ -123,6 +128,14 @@ class _NodeFuncFinder(ast.NodeVisitor):
             )
         elif call.name == "State":
             self.s = StateDefinition(name=name)
+        elif call.name == "Connection":
+            self.c.append(
+                ConnectionDefinition(
+                    name=name,
+                    domain=get("domain", str),
+                    description=get("description", str),
+                )
+            )
         else:
             raise RuntimeError("error in file parsing")  # unreachable
         if call.kwargs:

--- a/basis/utils/ast_parser.py
+++ b/basis/utils/ast_parser.py
@@ -10,7 +10,7 @@ from basis.graph.configured_node import (
     OutputDefinition,
     ParameterDefinition,
     PortType,
-    StateDefinition,
+    StateDefinition, ConnectionDefinition,
 )
 
 
@@ -36,6 +36,7 @@ class _NodeFuncFinder(ast.NodeVisitor):
         self.i: List[InputDefinition] = []
         self.o: List[OutputDefinition] = []
         self.p: List[ParameterDefinition] = []
+        self.c: List[ConnectionDefinition] = []
         self.s: Optional[StateDefinition] = None
         self.found = 0
 

--- a/basis/utils/ast_parser.py
+++ b/basis/utils/ast_parser.py
@@ -78,6 +78,7 @@ class _NodeFuncFinder(ast.NodeVisitor):
             "OutputStream",
             "Parameter",
             "State",
+            "Connection",
         ):
             raise ValueError(
                 f"node function parameter {name} must specify an input, output, or parameter, not {call.name}"

--- a/tests/graph/flat_graph/passthrough.py
+++ b/tests/graph/flat_graph/passthrough.py
@@ -3,12 +3,15 @@ from basis import *
 
 @node
 def passthrough_node(
-    source_stream=InputStream(description="in desc", schema="TestSchema",),
+    source_stream=InputStream(
+        description="in desc",
+        schema="TestSchema",
+    ),
     optional_stream=InputStream(required=False),
     passthrough_stream=OutputStream(description="out desc", schema="TestSchema2"),
     explicit_param=Parameter(description="param desc", type="bool", default=False),
     plain_param=Parameter,
     state_param=State,
-    conn_param=Connection("squareup.com"),
+    conn_param=Connection(domain="example.com", description="conn desc"),
 ):
     pass

--- a/tests/graph/flat_graph/passthrough.py
+++ b/tests/graph/flat_graph/passthrough.py
@@ -9,5 +9,6 @@ def passthrough_node(
     explicit_param=Parameter(description="param desc", type="bool", default=False),
     plain_param=Parameter,
     state_param=State,
+    conn_param=Connection("squareup.com"),
 ):
     pass

--- a/tests/graph/test_ast.py
+++ b/tests/graph/test_ast.py
@@ -22,3 +22,6 @@ def test_interface_parse():
 
     assert i.state is not None
     assert i.state.name == "state_param"
+    
+    assert len(i.connections) == 1
+    assert i.connections[0] == "state_param"

--- a/tests/graph/test_ast.py
+++ b/tests/graph/test_ast.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from basis.utils.ast_parser import read_interface_from_py_node_file
-from tests.graph.utils import istream, ostream, p
+from tests.graph.utils import istream, ostream, p, c
 
 
 def test_interface_parse():
@@ -22,6 +22,6 @@ def test_interface_parse():
 
     assert i.state is not None
     assert i.state.name == "state_param"
-    
+
     assert len(i.connections) == 1
-    assert i.connections[0] == "state_param"
+    assert i.connections[0] == c("conn_param", "example.com", "conn desc")

--- a/tests/graph/test_builder.py
+++ b/tests/graph/test_builder.py
@@ -6,7 +6,7 @@ from basis.configuration.path import NodeId
 from basis.graph.builder import graph_manifest_from_yaml, GraphManifest, GraphError
 from basis.graph.configured_node import CURRENT_MANIFEST_SCHEMA_VERSION, NodeType
 from tests.graph.utils import (
-c,
+    c,
     p,
     ostream,
     istream,
@@ -482,7 +482,9 @@ def test_err_unconnected_implicit_input(tmp_path: Path):
     )
 
     assert_nodes(
-        manifest, n("source"), n("sink", errors=['Cannot find output named "input"']),
+        manifest,
+        n("source"),
+        n("sink", errors=['Cannot find output named "input"']),
     )
 
 
@@ -504,7 +506,9 @@ def test_err_unconnected_explicit_input(tmp_path: Path):
     )
 
     assert_nodes(
-        manifest, n("source"), n("sink", errors=['Cannot find output named "nosink"']),
+        manifest,
+        n("source"),
+        n("sink", errors=['Cannot find output named "nosink"']),
     )
 
 

--- a/tests/graph/test_builder.py
+++ b/tests/graph/test_builder.py
@@ -6,6 +6,7 @@ from basis.configuration.path import NodeId
 from basis.graph.builder import graph_manifest_from_yaml, GraphManifest, GraphError
 from basis.graph.configured_node import CURRENT_MANIFEST_SCHEMA_VERSION, NodeType
 from tests.graph.utils import (
+c,
     p,
     ostream,
     istream,
@@ -42,6 +43,7 @@ def test_flat_graph():
                 ostream("passthrough_stream", "out desc", "TestSchema2"),
                 p("explicit_param", "bool", "param desc", False),
                 p("plain_param"),
+                c("conn_param", "example.com", "conn desc"),
                 s("state_param"),
             ],
             file_path="passthrough.py",

--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -19,6 +19,7 @@ from basis.graph.configured_node import (
     GraphManifest,
     GraphError,
     StateDefinition,
+    ConnectionDefinition,
 )
 
 
@@ -171,6 +172,7 @@ def n(
             inputs=[i for i in interface if isinstance(i, InputDefinition)],
             outputs=[i for i in interface if isinstance(i, OutputDefinition)],
             parameters=[i for i in interface if isinstance(i, ParameterDefinition)],
+            connections=[i for i in interface if isinstance(i, ConnectionDefinition)],
             state=next((i for i in interface if isinstance(i, StateDefinition)), None),
         ),
         description=description,
@@ -184,7 +186,10 @@ def n(
 
 
 def p(
-    name: str, parameter_type: str = None, description: str = None, default: Any = None,
+    name: str,
+    parameter_type: str = None,
+    description: str = None,
+    default: Any = None,
 ) -> ParameterDefinition:
     return ParameterDefinition(
         name=name,
@@ -194,8 +199,22 @@ def p(
     )
 
 
+def c(
+    name: str,
+    domain: str,
+    description: str = None,
+) -> ConnectionDefinition:
+    return ConnectionDefinition(
+        name=name,
+        domain=domain,
+        description=description,
+    )
+
+
 def ostream(
-    name: str, description: str = None, schema: Union[str, Schema] = None,
+    name: str,
+    description: str = None,
+    schema: Union[str, Schema] = None,
 ) -> OutputDefinition:
     return OutputDefinition(
         port_type=PortType.Stream,
@@ -236,7 +255,9 @@ def itable(
 
 
 def otable(
-    name: str, description: str = None, schema: Union[str, Schema] = None,
+    name: str,
+    description: str = None,
+    schema: Union[str, Schema] = None,
 ) -> OutputDefinition:
     return OutputDefinition(
         port_type=PortType.Table,


### PR DESCRIPTION
Adding a `Connection` param to node interface. Takes a domain name as input `conn=Connection(domain="stripe.com")`

Useful for:
* Providing abstraction for authentication to external services (TODO, but can link via `domain`)
* Allowing protocol to whitelist communication to specific domains (data security requirement when running arbitrary python)
* Allowing mock connections when testing
* Providing standardized and ergonomic methods for interacting with external APIs, hiding boiler plate