### PR TITLE
Improve help output

### DIFF
--- a/basis/cli/main.py
+++ b/basis/cli/main.py
@@ -11,7 +11,7 @@ from .commands.pull import pull, clone
 from .commands.trigger import trigger
 from .commands.upload import upload
 
-app = typer.Typer(name="basis", add_completion=False)
+app = typer.Typer(name="basis", add_completion=False, no_args_is_help=True)
 
 for command in (
     config,

--- a/basis/cli/main.py
+++ b/basis/cli/main.py
@@ -1,4 +1,7 @@
+from typing import List, Optional
+
 import typer
+from click import Group, Context, HelpFormatter, MultiCommand, Command
 
 from .commands.config import config
 from .commands.create import create
@@ -11,7 +14,51 @@ from .commands.pull import pull, clone
 from .commands.trigger import trigger
 from .commands.upload import upload
 
-app = typer.Typer(name="basis", add_completion=False, no_args_is_help=True)
+
+class _Command(Group):
+    def __init__(self):
+        super().__init__(name="basis", no_args_is_help=True)
+
+    def add_typer_fn(self, fn, **kw):
+        if isinstance(command, typer.Typer):
+            self.add_command(typer.main.get_command(fn))
+        else:
+            tmp = typer.Typer()
+            tmp.command(**kw)(command)
+            self.add_command(typer.main.get_command(tmp))
+
+    # override help output to include nested subcommands
+    def format_commands(self, ctx: Context, formatter: HelpFormatter) -> None:
+        old_list = self.list_commands
+        old_get = self.get_command
+
+        self.list_commands = self._list_commands
+        self.get_command = self._get_command
+
+        super().format_commands(ctx, formatter)
+
+        self.list_commands = old_list
+        self.get_command = old_get
+
+    def _list_commands(self, ctx: Context) -> List[str]:
+        l = super().list_commands(ctx)
+        for c in l:
+            sub = super().get_command(ctx, c)
+            if isinstance(sub, MultiCommand):
+                l.extend(f"{c} {s}" for s in sub.list_commands(ctx))
+        return l
+
+    def _get_command(self, ctx: Context, cmd_name: str) -> Optional[Command]:
+        parts = cmd_name.split()
+        base = super().get_command(ctx, parts[0])
+        if len(parts) == 1:
+            return base
+        assert len(parts) == 2
+        assert isinstance(base, MultiCommand)
+        return base.get_command(ctx, parts[1])
+
+
+app = _Command()
 
 for command in (
     config,
@@ -25,13 +72,10 @@ for command in (
     pull,
     clone,
 ):
-    if isinstance(command, typer.Typer):
-        app.add_typer(command)
-    else:
-        app.command()(command)
+    app.add_typer_fn(command)
 
 # don't show manifest command in help
-app.command(hidden=True)(manifest)
+app.add_typer_fn(manifest, hidden=True)
 
 
 def main():

--- a/basis/cli/services/api.py
+++ b/basis/cli/services/api.py
@@ -11,7 +11,9 @@ from basis.cli.config import (
 )
 from basis.cli.services.output import abort, abort_on_error
 
-API_BASE_URL = os.environ.get("BASIS_API_URL", "https://api-production.getbasis.com/")
+API_BASE_URL = (
+    os.environ.get("BASIS_API_URL", "https://api-production.getbasis.com/").rstrip("/") + "/"
+)
 AUTH_TOKEN_ENV_VAR = "BASIS_AUTH_TOKEN"
 AUTH_TOKEN_PREFIX = "JWT"
 

--- a/basis/cli/services/output.py
+++ b/basis/cli/services/output.py
@@ -77,7 +77,7 @@ def abort_on_error(message: str, prefix=": ", suffix=""):
         except Exception:
             details = e.response.text
         if not details:
-            details = f'HTTP {e.response.status_code}'
+            details = f"HTTP {e.response.status_code}"
         abort(f"{message}{prefix}{details}{suffix}")
     except (typer.Exit, typer.Abort) as e:
         raise e

--- a/basis/cli/services/output.py
+++ b/basis/cli/services/output.py
@@ -76,6 +76,8 @@ def abort_on_error(message: str, prefix=": ", suffix=""):
             details = e.response.json()["detail"]
         except Exception:
             details = e.response.text
+        if not details:
+            details = f'HTTP {e.response.status_code}'
         abort(f"{message}{prefix}{details}{suffix}")
     except (typer.Exit, typer.Abort) as e:
         raise e

--- a/tests/cli/base.py
+++ b/tests/cli/base.py
@@ -7,17 +7,16 @@ from pathlib import Path
 
 import click
 import requests_mock
-import typer.testing
 from click.testing import Result
 
 from basis.cli.config import BASIS_CONFIG_ENV_VAR, update_local_basis_config
-from basis.cli.services.api import API_BASE_URL, Endpoints
 from basis.cli.main import app
+from basis.cli.services.api import API_BASE_URL, Endpoints
 
 
 def run_cli(argv: str, input: str = None, **kwargs) -> click.testing.Result:
     args = shlex.split(argv.replace("\\", "/"))
-    runner = typer.testing.CliRunner()
+    runner = click.testing.CliRunner()
     result = runner.invoke(app, args, input, catch_exceptions=False, **kwargs)
     print(result.output)
     return result

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -27,6 +27,16 @@ def test_create_node(tmp_path: Path):
     assert name in (dr / "graph.yml").read_text()
 
 
+def test_create_subgraph(tmp_path: Path):
+    dr = set_tmp_dir(tmp_path).parent / "graph"
+    name = "sub/graph.yml"
+    run_cli("create graph", f"{dr}\n")
+    path = dr / name
+    run_cli(f"create node", f"{path}\n")
+    assert name in (dr / "graph.yml").read_text()
+    assert "sub" in path.read_text()
+
+
 def test_create_node_explicit(tmp_path: Path):
     dr = set_tmp_dir(tmp_path).parent / "graph"
     name = "mynode.py"


### PR DESCRIPTION
- print help on `basis` with no commands
- Make trailing slash optional in `API_BASE_URL` envvar
- print more info for `create node`
- add response status code for blank server errors
- add subgraph creation to `create node`
- list nested subcommands on top level help