### PR TITLE
Make `exposes` optional for subgraphs that aren't components

### DIFF
--- a/basis/cli/services/api.py
+++ b/basis/cli/services/api.py
@@ -12,7 +12,8 @@ from basis.cli.config import (
 from basis.cli.services.output import abort, abort_on_error
 
 API_BASE_URL = (
-    os.environ.get("BASIS_API_URL", "https://api-production.getbasis.com/").rstrip("/") + "/"
+    os.environ.get("BASIS_API_URL", "https://api-production.getbasis.com/").rstrip("/")
+    + "/"
 )
 AUTH_TOKEN_ENV_VAR = "BASIS_AUTH_TOKEN"
 AUTH_TOKEN_PREFIX = "JWT"

--- a/basis/graph/configured_node.py
+++ b/basis/graph/configured_node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Union, Optional
 
 from basis.configuration.base import FrozenPydanticBase
@@ -135,6 +136,18 @@ class GraphManifest(FrozenPydanticBase):
         for node in self.nodes:
             if node.name == name:
                 yield node
+
+    def get_node_with_file_path(
+        self, file_path_to_node_script_relative_to_root: Union[str, Path]
+    ) -> ConfiguredNode:
+        path = "/".join(Path(file_path_to_node_script_relative_to_root).parts)
+        for node in self.nodes:
+            if node.file_path_to_node_script_relative_to_root == path:
+                return node
+        raise ValueError(
+            f"No node in manifest with file_path: "
+            f"{file_path_to_node_script_relative_to_root}"
+        )
 
     def get_single_node_by_name(self, name: str) -> ConfiguredNode:
         nodes = list(self.get_nodes_by_name(name))

--- a/basis/node/node.py
+++ b/basis/node/node.py
@@ -32,19 +32,13 @@ def _mixin_attrs():
 # class will recursively produce more classes and never an actual instance, but that fine for how we're using them.
 class _InputMeta(type, _NodeInterfaceEntry):
     def __new__(
-        mcs,
-        description: str = None,
-        schema: str = None,
-        required: bool = True,
+        mcs, description: str = None, schema: str = None, required: bool = True,
     ):
         return super().__new__(mcs, mcs.__name__, (mcs,), _mixin_attrs())
 
     # noinspection PyMissingConstructor
     def __init__(
-        cls,
-        description: str = None,
-        schema: str = None,
-        required: bool = True,
+        cls, description: str = None, schema: str = None, required: bool = True,
     ):
         cls.description = description
         cls.schema = schema

--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -87,19 +87,23 @@ def _assert_node(
                 if assertion.parameter_values == IGNORE:
                     continue
                 v = {
-                    kk: ResolvedParameterValue(value=vv, source=node.id)
+                    kk: f"<ResolvedParam value={vv}, source={paths_by_id[node.id]}>"
                     for kk, vv in assertion.parameter_values.items()
                 }
             else:
                 v = {
-                    kk: ResolvedParameterValue(value=vv[0], source=ids_by_path[vv[1]])
+                    kk: f"<ResolvedParam value={vv[0]}, source={vv[1]}>"
                     for kk, vv in v.items()
                 }
+            actual = {
+                k: f"<ResolvedParam value={v.value}, source={paths_by_id[v.source]}>"
+                for k, v in actual.items()
+            }
 
         def check(k, ex, ac):
             assert ac == ex, (
                 f"{assertion.name}: {k}:\n  expected: {_tostr(ex, paths_by_id)}"
-                + f"\n   but was: {_tostr(ac, paths_by_id)}"
+                + f"\n  but was:  {_tostr(ac, paths_by_id)}"
             )
 
         if k == "interface":
@@ -230,10 +234,7 @@ def ostream(
 
 
 def istream(
-    name: str,
-    description: str = None,
-    schema: str = None,
-    required: bool = True,
+    name: str, description: str = None, schema: str = None, required: bool = True,
 ) -> InputDefinition:
     return InputDefinition(
         port_type=PortType.Stream,
@@ -245,10 +246,7 @@ def istream(
 
 
 def itable(
-    name: str,
-    description: str = None,
-    schema: str = None,
-    required: bool = True,
+    name: str, description: str = None, schema: str = None, required: bool = True,
 ) -> InputDefinition:
     return InputDefinition(
         port_type=PortType.Table,
@@ -259,9 +257,7 @@ def itable(
     )
 
 
-def otable(
-    name: str, description: str = None, schema: str = None,
-) -> OutputDefinition:
+def otable(name: str, description: str = None, schema: str = None,) -> OutputDefinition:
     return OutputDefinition(
         port_type=PortType.Table,
         name=name,


### PR DESCRIPTION
If omitted, all ports and parameters are exposed. Components must still declare an `exposes` block.