### PR TITLE
Add option to print stacktraces instead of error messages

### DIFF
--- a/basis/cli/main.py
+++ b/basis/cli/main.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+import click
 import typer
 from click import Group, Context, HelpFormatter, MultiCommand, Command
 
@@ -13,11 +14,19 @@ from .commands.manifest import manifest
 from .commands.pull import pull, clone
 from .commands.trigger import trigger
 from .commands.upload import upload
+from ..cli.services import output
 
 
 class _Command(Group):
     def __init__(self):
-        super().__init__(name="basis", no_args_is_help=True)
+        def debug_cb(ctx, p, v):
+            if v:
+                output.DEBUG = True
+
+        debug_opt = click.Option(
+            ["--stacktrace"], hidden=True, is_flag=True, callback=debug_cb
+        )
+        super().__init__(name="basis", no_args_is_help=True, params=[debug_opt])
 
     def add_typer_fn(self, fn, **kw):
         if isinstance(fn, typer.Typer):

--- a/basis/cli/services/output.py
+++ b/basis/cli/services/output.py
@@ -8,6 +8,9 @@ from requests import HTTPError
 from rich.console import Console
 from rich.theme import Theme
 
+"""Set to True to raise exceptions from cli commands rather than printing the message"""
+DEBUG = False
+
 console = Console(
     theme=(
         Theme(
@@ -69,6 +72,9 @@ def abort(message: str) -> typing.NoReturn:
 @contextlib.contextmanager
 def abort_on_error(message: str, prefix=": ", suffix=""):
     """Catch any exceptions that occur and call `abort` with their message"""
+    if DEBUG:
+        yield
+        return
     try:
         yield
     except HTTPError as e:


### PR DESCRIPTION
e.g. `basis --stacktrace list graphs`