### PR TITLE
Update Parameter implementation

### DIFF
--- a/basis/configuration/graph.py
+++ b/basis/configuration/graph.py
@@ -37,7 +37,7 @@ class PortMappingCfg(str):
 
     @classmethod
     def validate(cls, v):
-        if not (m := cls._regex.fullmatch(v)):
+        if not cls._regex.fullmatch(v):
             raise ValueError("invalid alias format")
         return cls(v)
 

--- a/basis/node/node.py
+++ b/basis/node/node.py
@@ -1,36 +1,30 @@
-import abc
-import inspect
 from dataclasses import dataclass
-from typing import Callable, List, Any
+from dataclasses import dataclass
+from typing import Callable, Any, TypeVar, Type
 
 from basis.node._methods import (
     InputTableMethods,
     OutputTableMethods,
-    ParameterMethods,
     InputStreamMethods,
     OutputStreamMethods,
     StateMethods,
 )
 
 
-class _NodeInterfaceEntry:
-    param_name: str
-
-
 def _mixin_attrs():
     def init(self, param_name):
         self.param_name = param_name
 
-    return {
-        "__init__": init,
-    }
+    return {"__init__": init}
 
 
-# In order to support type inference with both `Parameter` and `Parameter()` forms, we need to use the metaclass
-# mechanisms to return a type rather than a value when the classes are invoked. We add __init__ to the generated classes
-# so that invoking them generates new class objects with the description etc. set. This does mean that invoking the
-# class will recursively produce more classes and never an actual instance, but that fine for how we're using them.
-class _InputMeta(type, _NodeInterfaceEntry):
+# In order to support type inference with both `Parameter` and `Parameter()` forms, we
+# need to use the metaclass mechanisms to return a type rather than a value when the
+# classes are invoked. We add __init__ to the generated classes so that invoking them
+# generates new class objects with the description etc. set. This does mean that
+# invoking the class will recursively produce more classes and never an actual instance,
+# but that fine for how we're using them.
+class _InputMeta(type):
     def __new__(
         mcs, description: str = None, schema: str = None, required: bool = True,
     ):
@@ -45,7 +39,7 @@ class _InputMeta(type, _NodeInterfaceEntry):
         cls.required = required
 
 
-class _OutputMeta(type, _NodeInterfaceEntry):
+class _OutputMeta(type):
     def __new__(
         mcs, description: str = None, schema: str = None,
     ):
@@ -59,7 +53,7 @@ class _OutputMeta(type, _NodeInterfaceEntry):
         cls.schema = schema
 
 
-class _ParameterMeta(type, _NodeInterfaceEntry):
+class _StateMeta(type):
     def __new__(
         mcs, description: str = None, type: str = None, default: Any = None,
     ):
@@ -90,36 +84,32 @@ class OutputStream(_OutputMeta, OutputStreamMethods):
     pass
 
 
-class Parameter(_ParameterMeta, ParameterMethods):
+class State(_StateMeta, StateMethods):
     pass
 
 
-class State(_ParameterMeta, StateMethods):
-    pass
+T = TypeVar("T")
+
+
+class _Parameter(str):
+    def __call__(
+        self,
+        description: str = None,
+        type: Type[T] = str,
+        default: Any = None,
+        template: str = None,
+    ) -> T:
+        pass
+
+
+Parameter = _Parameter()
 
 
 @dataclass(frozen=True)
 class NodeFunction:
     function: Callable
-    args: List[_NodeInterfaceEntry]
 
 
 def node(function: Callable):
     """A decorator that registers a function to execute when a node runs"""
-
-    sig = inspect.signature(function)
-
-    args = []
-    for (name, param) in sig.parameters.items():
-        value = param.default
-        if value is inspect.Parameter.empty:
-            raise TypeError(f"{name} must have a type (e.g. {name}=InputTable)")
-
-        if inspect.isclass(value) and issubclass(value, _NodeInterfaceEntry):
-            if value.__class__ in (type, abc.ABCMeta):
-                value = value()
-            # noinspection PyCallingNonCallable
-            args.append(value(name))
-        else:
-            raise TypeError(f"{name} is not a valid node parameter type")
-    return NodeFunction(function, args)
+    return NodeFunction(function)


### PR DESCRIPTION
- Change `Parameter`'s `type` argument to take type instances rather than strings. 
- Support type inference for `Parameter` usage.
- Add `template` argument to `Parameter`.
- Remove runtime node function validation, since that's done at parse time now.