### PR TITLE
updating outblock block data endpoint

### DIFF
--- a/basis/cli/commands/list.py
+++ b/basis/cli/commands/list.py
@@ -85,7 +85,7 @@ def logs(
 
 _port_help = "The name of the output port"
 
-_node_title_help = "The node title of the store to get the latest output for"
+_store_name_help = "The name of the store to get the latest output for"
 _graph_help = "The location of the graph.yml file for the graph"
 
 
@@ -95,7 +95,7 @@ def output(
     organization: str = Option("", "-o", "--organization", help=_organization_help),
     environment: str = Option("", "-e", "--environment", help=_environment_help),
     graph: Path = Argument(None, exists=True, help=_graph_help),
-    node_title: str = Argument(..., exists=True, help=_node_title_help),
+    store_name: str = Argument(..., exists=True, help=_store_name_help),
 ):
     """List data sent to an output port of a from the most recent run of a node"""
     ids = IdLookup(
@@ -106,7 +106,7 @@ def output(
 
     with abort_on_error("Could not get node data"):
         data = list(
-            paginated_output_data(ids.environment_id, ids.graph_id, node_title)
+            paginated_output_data(ids.environment_id, ids.graph_id, store_name)
         )
     _print_objects(data, print_json)
 

--- a/basis/cli/commands/list.py
+++ b/basis/cli/commands/list.py
@@ -94,7 +94,7 @@ def output(
     print_json: bool = Option(False, "--json", help=_json_help),
     organization: str = Option("", "-o", "--organization", help=_organization_help),
     environment: str = Option("", "-e", "--environment", help=_environment_help),
-    graph: Path = Option("", "-p", "--graph_path", help=_graph_help),
+    graph: Path = Option("", "-g", "--graph-path", help=_graph_help),
     store_name: str = Argument(..., exists=True, help=_store_name_help),
 ):
     """List data sent to an output port of a from the most recent run of a node"""

--- a/basis/cli/commands/list.py
+++ b/basis/cli/commands/list.py
@@ -85,25 +85,25 @@ def logs(
 
 _port_help = "The name of the output port"
 
+_node_output_help = "The id of the node to get logs for"
+
 
 @list_command.command()
 def output(
     print_json: bool = Option(False, "--json", help=_json_help),
     organization: str = Option("", "-o", "--organization", help=_organization_help),
     environment: str = Option("", "-e", "--environment", help=_environment_help),
-    node: Path = Argument(..., exists=True, help=_node_help),
-    port: str = Argument(..., help=_port_help),
+    node_id: str = Argument(..., exists=True, help=_node_output_help),
 ):
     """List data sent to an output port of a from the most recent run of a node"""
     ids = IdLookup(
         environment_name=environment,
         organization_name=organization,
-        node_file_path=node,
     )
 
     with abort_on_error("Could not get node data"):
         data = list(
-            paginated_output_data(ids.environment_id, ids.graph_id, ids.node_id, port)
+            paginated_output_data(ids.environment_id, ids.graph_id, node_id)
         )
     _print_objects(data, print_json)
 

--- a/basis/cli/commands/list.py
+++ b/basis/cli/commands/list.py
@@ -86,6 +86,7 @@ def logs(
 _port_help = "The name of the output port"
 
 _node_output_help = "The id of the node to get logs for"
+_graph_help = "The location of the graph.yml file for the graph"
 
 
 @list_command.command()
@@ -93,12 +94,14 @@ def output(
     print_json: bool = Option(False, "--json", help=_json_help),
     organization: str = Option("", "-o", "--organization", help=_organization_help),
     environment: str = Option("", "-e", "--environment", help=_environment_help),
+    graph: Path = Argument(None, exists=True, help=_graph_help),
     node_id: str = Argument(..., exists=True, help=_node_output_help),
 ):
     """List data sent to an output port of a from the most recent run of a node"""
     ids = IdLookup(
         environment_name=environment,
         organization_name=organization,
+        explicit_graph_path=graph,
     )
 
     with abort_on_error("Could not get node data"):

--- a/basis/cli/commands/list.py
+++ b/basis/cli/commands/list.py
@@ -94,7 +94,7 @@ def output(
     print_json: bool = Option(False, "--json", help=_json_help),
     organization: str = Option("", "-o", "--organization", help=_organization_help),
     environment: str = Option("", "-e", "--environment", help=_environment_help),
-    graph: Path = Argument(None, exists=True, help=_graph_help),
+    graph: Path = Option("", "-p", "--graph_path", help=_graph_help),
     store_name: str = Argument(..., exists=True, help=_store_name_help),
 ):
     """List data sent to an output port of a from the most recent run of a node"""

--- a/basis/cli/commands/list.py
+++ b/basis/cli/commands/list.py
@@ -85,7 +85,7 @@ def logs(
 
 _port_help = "The name of the output port"
 
-_node_output_help = "The id of the node to get logs for"
+_node_title_help = "The node title of the store to get the latest output for"
 _graph_help = "The location of the graph.yml file for the graph"
 
 
@@ -95,7 +95,7 @@ def output(
     organization: str = Option("", "-o", "--organization", help=_organization_help),
     environment: str = Option("", "-e", "--environment", help=_environment_help),
     graph: Path = Argument(None, exists=True, help=_graph_help),
-    node_id: str = Argument(..., exists=True, help=_node_output_help),
+    node_title: str = Argument(..., exists=True, help=_node_title_help),
 ):
     """List data sent to an output port of a from the most recent run of a node"""
     ids = IdLookup(
@@ -106,7 +106,7 @@ def output(
 
     with abort_on_error("Could not get node data"):
         data = list(
-            paginated_output_data(ids.environment_id, ids.graph_id, node_id)
+            paginated_output_data(ids.environment_id, ids.graph_id, node_title)
         )
     _print_objects(data, print_json)
 

--- a/basis/cli/services/api.py
+++ b/basis/cli/services/api.py
@@ -129,7 +129,7 @@ class Endpoints:
     ENVIRONMENTS_CREATE = f"{PUBLIC_API_BASE_URL}/environments/"
     ORGANIZATIONS_LIST = f"{PUBLIC_API_BASE_URL}/organizations/"
     EXECUTION_EVENTS = f"{PUBLIC_API_BASE_URL}/nodes/execution_events/"
-    OUTPUT_DATA = f"{PUBLIC_API_BASE_URL}/nodes/output_block_data/latest/"
+    OUTPUT_DATA = f"{PUBLIC_API_BASE_URL}/nodes/store_data/latest/"
     WEBHOOKS = f"{PUBLIC_API_BASE_URL}/webhooks/"
     COMPONENTS_LIST = f"{PUBLIC_API_BASE_URL}/marketplace/components/"
     COMPONENTS_CREATE = f"{PUBLIC_API_BASE_URL}/marketplace/components/versions/"

--- a/basis/cli/services/list.py
+++ b/basis/cli/services/list.py
@@ -25,14 +25,14 @@ def paginated_execution_events(environment_uid: str, graph_uid: str, node_id: st
 
 @paginated
 def paginated_output_data(
-    environment_uid: str, graph_uid: str, node_id: str
+    environment_uid: str, graph_uid: str, node_title: str
 ):
     return get_json(
         Endpoints.OUTPUT_DATA,
         params={
             "environment_uid": environment_uid,
             "graph_uid": graph_uid,
-            "node_id": node_id,
+            "node_title": node_title,
         },
     )
 

--- a/basis/cli/services/list.py
+++ b/basis/cli/services/list.py
@@ -25,7 +25,7 @@ def paginated_execution_events(environment_uid: str, graph_uid: str, node_id: st
 
 @paginated
 def paginated_output_data(
-    environment_uid: str, graph_uid: str, node_id: str, output_port_name: str
+    environment_uid: str, graph_uid: str, node_id: str
 ):
     return get_json(
         Endpoints.OUTPUT_DATA,
@@ -33,7 +33,6 @@ def paginated_output_data(
             "environment_uid": environment_uid,
             "graph_uid": graph_uid,
             "node_id": node_id,
-            "output_port_name": output_port_name,
         },
     )
 

--- a/basis/cli/services/list.py
+++ b/basis/cli/services/list.py
@@ -25,14 +25,14 @@ def paginated_execution_events(environment_uid: str, graph_uid: str, node_id: st
 
 @paginated
 def paginated_output_data(
-    environment_uid: str, graph_uid: str, node_title: str
+    environment_uid: str, graph_uid: str, store_name: str
 ):
     return get_json(
         Endpoints.OUTPUT_DATA,
         params={
             "environment_uid": environment_uid,
             "graph_uid": graph_uid,
-            "node_title": node_title,
+            "store_name": store_name,
         },
     )
 

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -45,10 +45,9 @@ def test_list_data(tmp_path: Path):
     path = dr / "name"
     node = path / "node.py"
     run_cli(f"create graph {path}")
-    r = run_cli(f"create node {node}")
+    run_cli(f"create node {node}")
 
-    editor = GraphConfigEditor(path / "graph.yml")
-    node_id = list(editor.function_nodes())[0]['id']
+    node_name = "test"
 
     with request_mocker() as m:
         m.get(
@@ -59,7 +58,7 @@ def test_list_data(tmp_path: Path):
             API_BASE_URL + Endpoints.OUTPUT_DATA,
             json={"results": [{"name": "name"}], "next": None},
         )
-        result = run_cli(f"list output {path} {node_id} --json")
+        result = run_cli(f"list output {path} {node_name} --json")
     assert "name" in result.output
 
 

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from basis.cli.services.api import API_BASE_URL, Endpoints
+from basis.configuration.edit import GraphConfigEditor
 from tests.cli.base import request_mocker, set_tmp_dir, run_cli
 
 
@@ -44,7 +45,11 @@ def test_list_data(tmp_path: Path):
     path = dr / "name"
     node = path / "node.py"
     run_cli(f"create graph {path}")
-    run_cli(f"create node {node}")
+    r = run_cli(f"create node {node}")
+
+    editor = GraphConfigEditor(path / "graph.yml")
+    node_id = list(editor.function_nodes())[0]['id']
+
     with request_mocker() as m:
         m.get(
             API_BASE_URL + Endpoints.graph_by_name("test-org-uid", "name"),
@@ -54,7 +59,7 @@ def test_list_data(tmp_path: Path):
             API_BASE_URL + Endpoints.OUTPUT_DATA,
             json={"results": [{"name": "name"}], "next": None},
         )
-        result = run_cli(f"list output {node} port --json")
+        result = run_cli(f"list output {path} {node_id} --json")
     assert "name" in result.output
 
 

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -58,7 +58,7 @@ def test_list_data(tmp_path: Path):
             API_BASE_URL + Endpoints.OUTPUT_DATA,
             json={"results": [{"name": "name"}], "next": None},
         )
-        result = run_cli(f"list output {store_name} -p {path} --json")
+        result = run_cli(f"list output {store_name} -g {path} --json")
     assert "name" in result.output
 
 

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -58,7 +58,7 @@ def test_list_data(tmp_path: Path):
             API_BASE_URL + Endpoints.OUTPUT_DATA,
             json={"results": [{"name": "name"}], "next": None},
         )
-        result = run_cli(f"list output {path} {store_name} --json")
+        result = run_cli(f"list output {store_name} -p {path} --json")
     assert "name" in result.output
 
 

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -47,7 +47,7 @@ def test_list_data(tmp_path: Path):
     run_cli(f"create graph {path}")
     run_cli(f"create node {node}")
 
-    node_name = "test"
+    store_name = "test"
 
     with request_mocker() as m:
         m.get(
@@ -58,7 +58,7 @@ def test_list_data(tmp_path: Path):
             API_BASE_URL + Endpoints.OUTPUT_DATA,
             json={"results": [{"name": "name"}], "next": None},
         )
-        result = run_cli(f"list output {path} {node_name} --json")
+        result = run_cli(f"list output {path} {store_name} --json")
     assert "name" in result.output
 
 


### PR DESCRIPTION
Output block data is replaced by store data - PR: https://github.com/basis-os/basis-api/pull/515
Update the endpoint URL and params (output_port_name is no longer needed since you get the store data from a store node and so you pass the store node title instead)

I'm assuming more devkit changes will be coming to work with the new store node model (maybe?), this PR is mostly just to document the endpoint change. So feel free to use/revise as needed!