### PR TITLE
update click version to fix bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = "^3.8"
 rich = "^12.0.1"
 ruyaml = "^0.91.0"
 # workaround for bug in typer 0.4 (https://github.com/tiangolo/typer/issues/377)
-click = "^7.1.1"
+click = "8.0.4"
 typer = {extras = ["all"], version = "^0.4.0"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The API server uses the devkit which uses typer/click and there's a bug with typer/click (https://github.com/tiangolo/typer/issues/377), I think fixing the version of typer here, should fix the resulting issue in the API server. 
Lmk what you think! 

black (22.1.0) depends on click (>=8.0.0) and 
basis-devkit depends on click (^7.1.1), black (>=22.1.0,<23.0.0) is incompatible with basis-devkit
So I think we need to update click version in devkit to 8.0.4 (but not 8.1.0) and that will resolve these issues