### PR TITLE
updating for v0 endpoint cleanup

### DIFF
--- a/basis/cli/commands/upload.py
+++ b/basis/cli/commands/upload.py
@@ -38,11 +38,10 @@ def upload(
 
     graph_version_id = resp["uid"]
     ui_url = resp["ui_url"]
-    manifest = resp["manifest"]
     sprint(f"\n[success]Uploaded new graph version with id [b]{graph_version_id}")
-    if manifest.get("errors"):
+    if resp.get("errors"):
         sprint(f"[error]Graph contains the following errors:")
-        for error in manifest["errors"]:
+        for error in resp["errors"]:
             sprint(f"\t[error]{error}")
 
     if publish_component:

--- a/basis/cli/services/api.py
+++ b/basis/cli/services/api.py
@@ -168,8 +168,8 @@ class Endpoints:
         return f"{PUBLIC_API_BASE_URL}/graph_versions/{graph_version_uid}/zip/"
 
     @classmethod
-    def graph_by_name(cls, organization_uid: str, name: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/graphs/name/{name}/"
+    def graph_by_slug(cls, organization_uid: str, slug: str) -> str:
+        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/graphs/slug/{slug}/"
 
     @classmethod
     def graph_version_by_id(cls, graph_version_uid: str) -> str:

--- a/basis/cli/services/api.py
+++ b/basis/cli/services/api.py
@@ -16,10 +16,11 @@ API_BASE_URL = (
     os.environ.get("BASIS_API_URL", "https://api-production.getbasis.com/").rstrip("/")
     + "/"
 )
+
 AUTH_TOKEN_ENV_VAR = "BASIS_AUTH_TOKEN"
 AUTH_TOKEN_PREFIX = "JWT"
 
-PUBLIC_API_BASE_URL = "api/v0"
+PUBLIC_API_BASE_URL = "api/v1"
 
 
 def _get_api_session() -> Session:
@@ -133,60 +134,60 @@ def post(
 
 
 class Endpoints:
-    TOKEN_CREATE = "auth/jwt/create/"
-    TOKEN_AUTHSERVER = f"{PUBLIC_API_BASE_URL}/auth/jwt/authserver/"
-    TOKEN_VERIFY = f"{PUBLIC_API_BASE_URL}/auth/jwt/verify/"
-    ACCOUNTS_ME = f"{PUBLIC_API_BASE_URL}/accounts/me/"
-    DEPLOYMENTS_DEPLOY = f"{PUBLIC_API_BASE_URL}/deployments/"
-    DEPLOYMENTS_TRIGGER_NODE = f"{PUBLIC_API_BASE_URL}/deployments/triggers/"
-    ENVIRONMENTS_CREATE = f"{PUBLIC_API_BASE_URL}/environments/"
-    ORGANIZATIONS_LIST = f"{PUBLIC_API_BASE_URL}/organizations/"
-    EXECUTION_EVENTS = f"{PUBLIC_API_BASE_URL}/nodes/execution_events/"
-    OUTPUT_DATA = f"{PUBLIC_API_BASE_URL}/nodes/store_data/latest/"
-    WEBHOOKS = f"{PUBLIC_API_BASE_URL}/webhooks/"
-    COMPONENTS_LIST = f"{PUBLIC_API_BASE_URL}/marketplace/components/"
-    COMPONENTS_CREATE = f"{PUBLIC_API_BASE_URL}/marketplace/components/versions/"
+    TOKEN_CREATE = "auth/jwt/create"
+    TOKEN_AUTHSERVER = f"{PUBLIC_API_BASE_URL}/auth/jwt/authserver"
+    TOKEN_VERIFY = f"{PUBLIC_API_BASE_URL}/auth/jwt/verify"
+    ACCOUNTS_ME = f"{PUBLIC_API_BASE_URL}/accounts/me"
+    DEPLOYMENTS_DEPLOY = f"{PUBLIC_API_BASE_URL}/deployments"
+    DEPLOYMENTS_TRIGGER_NODE = f"{PUBLIC_API_BASE_URL}/deployments/triggers"
+    ENVIRONMENTS_CREATE = f"{PUBLIC_API_BASE_URL}/environments"
+    ORGANIZATIONS_LIST = f"{PUBLIC_API_BASE_URL}/organizations"
+    EXECUTION_EVENTS = f"{PUBLIC_API_BASE_URL}/nodes/execution_events"
+    OUTPUT_DATA = f"{PUBLIC_API_BASE_URL}/nodes/store_data/latest"
+    WEBHOOKS = f"{PUBLIC_API_BASE_URL}/webhooks"
+    COMPONENTS_LIST = f"{PUBLIC_API_BASE_URL}/marketplace/components"
+    COMPONENTS_CREATE = f"{PUBLIC_API_BASE_URL}/marketplace/components/versions"
 
     @classmethod
     def organization_by_slug(cls, slug: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/slug/{slug}/"
+        return f"{PUBLIC_API_BASE_URL}/organizations/slug/{slug}"
 
     @classmethod
     def organization_by_id(cls, organization_uid: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/"
+        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}"
 
     @classmethod
     def graphs_list(cls, organization_uid: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/graphs/"
+        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/graphs"
 
     @classmethod
     def graphs_latest(cls, graph_uid: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/graphs/{graph_uid}/latest/"
+        return f"{PUBLIC_API_BASE_URL}/graphs/{graph_uid}/latest"
 
     @classmethod
     def graph_version_download(cls, graph_version_uid: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/graph_versions/{graph_version_uid}/zip/"
+        return f"{PUBLIC_API_BASE_URL}/graph_versions/{graph_version_uid}/zip"
 
     @classmethod
     def graph_by_slug(cls, organization_uid: str, slug: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/graphs/slug/{slug}/"
+        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/graphs/slug/{slug}"
 
     @classmethod
     def graph_version_by_id(cls, graph_version_uid: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/graph_versions/{graph_version_uid}/"
+        return f"{PUBLIC_API_BASE_URL}/graph_versions/{graph_version_uid}"
 
     @classmethod
     def graph_version_create(cls, organization_uid: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/graph_versions/"
+        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/graph_versions"
 
     @classmethod
     def environments_list(cls, organization_uid: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/environments/"
+        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/environments"
 
     @classmethod
     def environment_by_slug(cls, organization_uid: str, slug: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/environments/slug/{slug}/"
+        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/environments/slug/{slug}"
 
     @classmethod
     def environment_by_id(cls, environment_uid: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/environments/{environment_uid}/"
+        return f"{PUBLIC_API_BASE_URL}/environments/{environment_uid}"

--- a/basis/cli/services/api.py
+++ b/basis/cli/services/api.py
@@ -148,8 +148,8 @@ class Endpoints:
     COMPONENTS_CREATE = f"{PUBLIC_API_BASE_URL}/marketplace/components/versions/"
 
     @classmethod
-    def organization_by_name(cls, name: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/name/{name}/"
+    def organization_by_slug(cls, slug: str) -> str:
+        return f"{PUBLIC_API_BASE_URL}/organizations/slug/{slug}/"
 
     @classmethod
     def organization_by_id(cls, organization_uid: str) -> str:
@@ -184,8 +184,8 @@ class Endpoints:
         return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/environments/"
 
     @classmethod
-    def environment_by_name(cls, organization_uid: str, name: str) -> str:
-        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/environments/name/{name}/"
+    def environment_by_slug(cls, organization_uid: str, slug: str) -> str:
+        return f"{PUBLIC_API_BASE_URL}/organizations/{organization_uid}/environments/slug/{slug}/"
 
     @classmethod
     def environment_by_id(cls, environment_uid: str) -> str:

--- a/basis/cli/services/environments.py
+++ b/basis/cli/services/environments.py
@@ -5,7 +5,7 @@ from basis.cli.services.pagination import paginated
 
 
 def get_environment_by_name(organization_uid: str, name: str) -> dict:
-    return get_json(Endpoints.environment_by_name(organization_uid, name))
+    return get_json(Endpoints.environment_by_slug(organization_uid, name))
 
 
 def get_environment_by_id(environment_uid: str) -> dict:

--- a/basis/cli/services/graph_versions.py
+++ b/basis/cli/services/graph_versions.py
@@ -11,5 +11,5 @@ def get_graph_version_by_id(graph_version_uid) -> dict:
     return get_json(Endpoints.graph_version_by_id(graph_version_uid))
 
 
-def get_active_graph_version(graph_uid: str) -> dict:
-    return get_json(Endpoints.graphs_latest(graph_uid))["active_graph_version"]
+def get_latest_graph_version(graph_uid: str) -> dict:
+    return get_json(Endpoints.graphs_latest(graph_uid))["latest_graph_version"]

--- a/basis/cli/services/graph_versions.py
+++ b/basis/cli/services/graph_versions.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from basis.cli.services.api import Endpoints, get_json
 
 
-def get_graph_by_name(organization_uid: str, name: str) -> dict:
-    return get_json(Endpoints.graph_by_name(organization_uid, name))
+def get_graph_by_slug(organization_uid: str, slug: str) -> dict:
+    return get_json(Endpoints.graph_by_slug(organization_uid, slug))
 
 
 def get_graph_version_by_id(graph_version_uid) -> dict:

--- a/basis/cli/services/lookup.py
+++ b/basis/cli/services/lookup.py
@@ -17,7 +17,7 @@ from basis.cli.services.environments import (
 )
 from basis.cli.services.graph import resolve_graph_path
 from basis.cli.services.graph_versions import (
-    get_graph_by_name,
+    get_graph_by_slug,
     get_active_graph_version,
     get_graph_version_by_id,
 )
@@ -93,7 +93,7 @@ class IdLookup:
 
     @cached_property
     def graph_id(self) -> str:
-        return get_graph_by_name(self.organization_id, self.graph_name)["uid"]
+        return get_graph_by_slug(self.organization_id, self.graph_name)["uid"]
 
     @cached_property
     def graph_version_id(self):

--- a/basis/cli/services/lookup.py
+++ b/basis/cli/services/lookup.py
@@ -18,7 +18,7 @@ from basis.cli.services.environments import (
 from basis.cli.services.graph import resolve_graph_path
 from basis.cli.services.graph_versions import (
     get_graph_by_slug,
-    get_active_graph_version,
+    get_latest_graph_version,
     get_graph_version_by_id,
 )
 from basis.cli.services.organizations import (
@@ -99,7 +99,7 @@ class IdLookup:
     def graph_version_id(self):
         if self.explicit_graph_version_id:
             return self.explicit_graph_version_id
-        return get_active_graph_version(self.graph_id)["uid"]
+        return get_latest_graph_version(self.graph_id)["uid"]
 
     @cached_property
     def node_id(self) -> str:

--- a/basis/cli/services/organizations.py
+++ b/basis/cli/services/organizations.py
@@ -5,7 +5,7 @@ from basis.cli.services.pagination import paginated
 
 
 def get_organization_by_name(name: str) -> dict:
-    return get_json(Endpoints.organization_by_name(name))
+    return get_json(Endpoints.organization_by_slug(name))
 
 
 def get_organization_by_id(organization_uid: str) -> dict:

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -13,11 +13,11 @@ def test_config_org_and_env(tmp_path: Path):
 
     with request_mocker() as m:
         m.get(
-            API_BASE_URL + Endpoints.organization_by_name("org"),
+            API_BASE_URL + Endpoints.organization_by_slug("org"),
             json={"uid": "org-uid"},
         )
         m.get(
-            API_BASE_URL + Endpoints.environment_by_name("org-uid", "env"),
+            API_BASE_URL + Endpoints.environment_by_slug("org-uid", "env"),
             json={"uid": "env-uid"},
         )
         run_cli("config -o org -e env")

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -18,7 +18,7 @@ def test_deploy(tmp_path: Path):
                 json={"uid": "1", "ui_url": "url.com", "graph": {"name": "g"}, "manifest":{}},
             )
         for e in [
-            Endpoints.graph_by_name("test-org-uid", "name"),
+            Endpoints.graph_by_slug("test-org-uid", "name"),
             Endpoints.graphs_latest("1"),
         ]:
             m.get(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -23,7 +23,7 @@ def test_deploy(tmp_path: Path):
         ]:
             m.get(
                 API_BASE_URL + e,
-                json={"uid": "1", "active_graph_version": {"uid": "1"}},
+                json={"uid": "1", "latest_graph_version": {"uid": "1"}},
             )
 
         run_cli(f"create graph {path}")

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -29,7 +29,7 @@ def test_list_logs(tmp_path: Path):
     run_cli(f"create node {node}")
     with request_mocker() as m:
         m.get(
-            API_BASE_URL + Endpoints.graph_by_name("test-org-uid", "name"),
+            API_BASE_URL + Endpoints.graph_by_slug("test-org-uid", "name"),
             json={"uid": "1"},
         )
         m.get(
@@ -51,7 +51,7 @@ def test_list_data(tmp_path: Path):
 
     with request_mocker() as m:
         m.get(
-            API_BASE_URL + Endpoints.graph_by_name("test-org-uid", "name"),
+            API_BASE_URL + Endpoints.graph_by_slug("test-org-uid", "name"),
             json={"uid": "1"},
         )
         m.get(
@@ -70,7 +70,7 @@ def test_list_webhooks(tmp_path: Path):
     run_cli(f"create webhook --graph='{path}' undeployed_webhook")
     with request_mocker() as m:
         m.get(
-            API_BASE_URL + Endpoints.graph_by_name("test-org-uid", "name"),
+            API_BASE_URL + Endpoints.graph_by_slug("test-org-uid", "name"),
             json={"uid": "1"},
         )
         m.get(

--- a/tests/cli/test_trigger.py
+++ b/tests/cli/test_trigger.py
@@ -18,7 +18,7 @@ def test_trigger_node_in_subgraph(tmp_path: Path):
             API_BASE_URL + Endpoints.DEPLOYMENTS_TRIGGER_NODE, json={"uid": "1"},
         )
         m.get(
-            API_BASE_URL + Endpoints.graph_by_name("test-org-uid", "graph"),
+            API_BASE_URL + Endpoints.graph_by_slug("test-org-uid", "graph"),
             json={"uid": "2"},
         )
         m.get(

--- a/tests/cli/test_trigger.py
+++ b/tests/cli/test_trigger.py
@@ -23,7 +23,7 @@ def test_trigger_node_in_subgraph(tmp_path: Path):
         )
         m.get(
             API_BASE_URL + Endpoints.graphs_latest("2"),
-            json={"active_graph_version": {"uid": "3"}},
+            json={"latest_graph_version": {"uid": "3"}},
         )
         result = run_cli(f"trigger {name}")
         assert "Triggered node" in result.output

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -39,9 +39,7 @@ def node_fn(output=OutputTable):
                     "uid": "1",
                     "ui_url": "url.com",
                     "graph": {"name": "g"},
-                    "manifest": {
-                        "errors": [{"node_id": "n1", "message": "Test Error"}]
-                    },
+                    "errors": [{"node_id": "n1", "message": "Test Error"}]
                 },
             )
         result = run_cli(f"upload {path}")
@@ -77,7 +75,7 @@ def test_upload_component(tmp_path: Path):
                     "uid": "1",
                     "ui_url": "url.com",
                     "graph": {"name": "g"},
-                    "manifest": {"errors": []},
+                    "errors": []
                 },
             )
         m.post(


### PR DESCRIPTION
- GraphVersionResponse - doesn't return manifest or graph zip, but does include manifest errors
- active_graph_version -> latest_graph_version for GraphLatestResponse
- changed "/organizations/{organization_uid}/graphs/name/{name}/", to "/organizations/{organization_uid}/graphs/slug/{slug}/",
- changed "/organizations/{organization_uid}/environments/name/{name}/", to "/organizations/{organization_uid}/environments/slug/{slug}/",
- changed "/organizations/name/{name}/", to "/organizations/slug/{slug}/",


Corresponding API PR: https://github.com/basis-os/basis-api/pull/645