### PR TITLE
Remove unused parameter

### DIFF
--- a/basis/node/node.py
+++ b/basis/node/node.py
@@ -91,7 +91,6 @@ class _Parameter(str):
         description: str = None,
         type: Type[T] = str,
         default: Any = None,
-        template: str = None,
     ) -> T:
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,17 +14,16 @@ pydantic = "^1.8.1"
 python = "^3.8"
 rich = "^12.0.1"
 ruyaml = "^0.91.0"
-# workaround for bug in typer 0.4 (https://github.com/tiangolo/typer/issues/377)
-click = "8.0.4"
-typer = {extras = ["all"], version = "^0.4.0"}
+click = "^8.1.0"
+typer = {extras = ["all"], version = "^0.4.1"}
 
 [tool.poetry.dev-dependencies]
-black = "^19.10b0"
+black = "^22.3.0"
 flake8 = "^4.0.1"
 isort = "^4.3.21"
 mypy = "^0.910"
 pre-commit = "^2.1.1"
-pytest = "^6.2.5"
+pytest = "^7.1.1"
 requests-mock = "^1.9.3"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Remove `Parameter(template)` and update dependencies to remove the workaround there.