### PR TITLE
Allow custom names for graph.yml

### DIFF
--- a/basis/cli/services/graph.py
+++ b/basis/cli/services/graph.py
@@ -14,7 +14,7 @@ def resolve_graph_path(
         if exists:
             raise ValueError(f"File '{f}' does not exist")
         return f.absolute()
-    if path.suffix and path.name != "graph.yml":
+    if path.suffix and path.suffix not in (".yml", ".yaml"):
         raise ValueError(f"Invalid graph file name: {path.name}")
     if path.is_file():
         if not exists:

--- a/basis/cli/services/upload.py
+++ b/basis/cli/services/upload.py
@@ -11,8 +11,9 @@ def upload_graph_version(
     editor = GraphDirectoryEditor(graph_yaml_path)
     if add_missing_node_ids:
         editor.add_missing_node_ids()
+    payload = {"slug": editor.graph_slug(), "root_yaml_path": editor.yml_path.name}
     return post_for_json(
         Endpoints.graph_version_create(organization_uid),
-        data={"payload": json.dumps({"slug": editor.graph_slug()})},
+        data={"payload": json.dumps(payload)},
         files={"file": editor.compress_directory()},
     )


### PR DESCRIPTION
If you name your graph yaml with a custom name, you'll have to pass it explicitly to all commands (e.g. `basis upload custom.yml`) since we still only look for `graph.yml` as a default.